### PR TITLE
Add parameters to RPC to achieve export with single call.

### DIFF
--- a/src/vf_export.cpp
+++ b/src/vf_export.cpp
@@ -23,12 +23,7 @@ bool vf_export::initOnce()
         m_isInitalized=true;
         m_entity->initModule();
         m_entity->createComponent("EntityName","ExportModule",true);
-        m_inputPath=m_entity->createComponent("PAR_InputPath",QString(),true);
-        m_outputPath=m_entity->createComponent("PAR_OutputPath",QString(),true);
-        m_session=m_entity->createComponent("PAR_Session",QString(),true);
-        m_engine=m_entity->createComponent("PAR_Engine",QString(),true);
         m_status=m_entity->createComponent("Status",false,true);
-
         m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"}}));
         py =  new zPyInt::PythonBinding();
         if(py->init("pythonconverter_pkg.CppInterface") == true){
@@ -62,10 +57,10 @@ QVariant vf_export::RPC_Convert(QVariantMap p_params)
         retVal=false;
     }
     else if(m_inputPath != "" && m_outputPath != "" && m_session != ""){
-        py->callFunction("setInputPath",{PyUnicode_InternFromString(m_inputPath.value().toUtf8())});
-        py->callFunction("setOutputPath",{PyUnicode_FromString(m_outputPath.value().toUtf8())});
-        py->callFunction("setEngine",{PyUnicode_FromString(m_engine.value().toUtf8())});
-        py->callFunction("setSession",{PyUnicode_FromString(m_session.value().toUtf8())});
+        py->callFunction("setInputPath",{PyUnicode_InternFromString(m_inputPath.toUtf8())});
+        py->callFunction("setOutputPath",{PyUnicode_FromString(m_outputPath.toUtf8())});
+        py->callFunction("setEngine",{PyUnicode_FromString(m_engine.toUtf8())});
+        py->callFunction("setSession",{PyUnicode_FromString(m_session.toUtf8())});
         zPyInt::PySharedRef good =py->callFunction("checkInputFile",{});
         if(PyObject_IsTrue(good.data())){
             zPyInt::PySharedRef ret=py->callFunction("convert",{});

--- a/src/vf_export.cpp
+++ b/src/vf_export.cpp
@@ -23,13 +23,13 @@ bool vf_export::initOnce()
         m_isInitalized=true;
         m_entity->initModule();
         m_entity->createComponent("EntityName","ExportModule",true);
-        m_inputPath=m_entity->createComponent("PAR_InputPath",QString());
-        m_outputPath=m_entity->createComponent("PAR_OutputPath",QString());
-        m_session=m_entity->createComponent("PAR_Session",QString());
-        m_engine=m_entity->createComponent("PAR_Engine",QString());
+        m_inputPath=m_entity->createComponent("PAR_InputPath",QString(),true);
+        m_outputPath=m_entity->createComponent("PAR_OutputPath",QString(),true);
+        m_session=m_entity->createComponent("PAR_Session",QString(),true);
+        m_engine=m_entity->createComponent("PAR_Engine",QString(),true);
         m_status=m_entity->createComponent("Status",false,true);
 
-        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({}));
+        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"}}));
         py =  new zPyInt::PythonBinding();
         if(py->init("pythonconverter_pkg.CppInterface") == true){
             m_status=true;
@@ -52,6 +52,12 @@ void vf_export::setVeinEntity(VfCpp::veinmoduleentity *value)
 QVariant vf_export::RPC_Convert(QVariantMap p_params)
 {
     bool retVal = false;
+
+    m_inputPath=p_params["p_inputPath"].toString();
+    m_outputPath=p_params["p_outputPath"].toString();
+    m_engine=p_params["p_engine"].toString();
+    m_session=p_params["p_session"].toString();
+
     if(m_status == false){
         retVal=false;
     }

--- a/src/vf_export.h
+++ b/src/vf_export.h
@@ -69,22 +69,22 @@ private:
      * @brief m_iPath vein component
      * Path to sqlite db
      */
-    VfCpp::VeinCompProxy<QString> m_inputPath;
+    QString m_inputPath;
     /**
      * @brief m_oPath vein component
      * Path to xml File
      */
-    VfCpp::VeinCompProxy<QString> m_outputPath;
+    QString m_outputPath;
     /**
      * @brief m_session vein component
      * session to be converted
      */
-    VfCpp::VeinCompProxy<QString> m_session;
+    QString m_session;
     /**
      * @brief m_engine vein component
      * Conversion engine path
      */
-    VfCpp::VeinCompProxy<QString> m_engine;
+    QString m_engine;
 
     /**
      * @brief m_status


### PR DESCRIPTION
All components are readonly now.

Following parameters are added:
p_session, p_inputPath, p_outputPath, p_engine
all of type QString.

Signed-off-by: bhamacher <b.hamacher@zera.de>