### PR TITLE
Added Engine params to convert rpc.

### DIFF
--- a/src/vf_export.cpp
+++ b/src/vf_export.cpp
@@ -24,7 +24,7 @@ bool vf_export::initOnce()
         m_entity->initModule();
         m_entity->createComponent("EntityName","ExportModule",true);
         m_status=m_entity->createComponent("Status",false,true);
-        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"}}));
+        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"},{"p_parameters", "QString"}}));
         py =  new zPyInt::PythonBinding();
         if(py->init("pythonconverter_pkg.CppInterface") == true){
             m_status=true;
@@ -52,6 +52,7 @@ QVariant vf_export::RPC_Convert(QVariantMap p_params)
     m_outputPath=p_params["p_outputPath"].toString();
     m_engine=p_params["p_engine"].toString();
     m_session=p_params["p_session"].toString();
+    m_parameters=p_params["p_parameters"].toString();
 
     if(m_status == false){
         retVal=false;
@@ -61,6 +62,7 @@ QVariant vf_export::RPC_Convert(QVariantMap p_params)
         py->callFunction("setOutputPath",{PyUnicode_FromString(m_outputPath.toUtf8())});
         py->callFunction("setEngine",{PyUnicode_FromString(m_engine.toUtf8())});
         py->callFunction("setSession",{PyUnicode_FromString(m_session.toUtf8())});
+        py->callFunction("setParams",{PyUnicode_FromString(m_parameters.toUtf8())});
         zPyInt::PySharedRef good =py->callFunction("checkInputFile",{});
         if(PyObject_IsTrue(good.data())){
             zPyInt::PySharedRef ret=py->callFunction("convert",{});

--- a/src/vf_export.h
+++ b/src/vf_export.h
@@ -85,6 +85,19 @@ private:
      * Conversion engine path
      */
     QString m_engine;
+    /**
+     * @brief m_parameters
+     * stores the engine parameters available using setParameters
+     * inside the engine.
+     *
+     * The parameters are stores in a json object. Its a generic solution
+     * to adapt the parameters to the used engine.
+     *
+     * Please make sure to use ' instead of " in the json param object.
+     *
+     * {..."p_param" : "{'par1': 'val1', 'par2' : 'val2'}"
+     */
+    QString m_parameters;
 
     /**
      * @brief m_status


### PR DESCRIPTION
use with parameters as follow:

{"p_engine" : "", "p_inputPath" : "", "p_outputPath" : "", "p_session" : "", p_parameters : "{'par1' : 'val1', ...}"}

First use is digits, decimal places and local for MTVisRes engine:

parameters e.g. :

{"p_engine" : "zeraconverterengines.MTVisRes", "p_inputPath" : "", "p_outputPath" : "", "p_session" : "", p_parameters : "{'digits' : '8', 'decimalPlaces' : '4', 'local' : 'de_DE'}"}

Signed-off-by: bhamacher <b.hamacher@zera.de>