### PR TITLE
Adapted vf-export to newVein prepared vf-cpp interface.

### DIFF
--- a/src/vf_export.cpp
+++ b/src/vf_export.cpp
@@ -12,18 +12,19 @@
 using namespace vfExport;
 
 vf_export::vf_export(QObject *parent, int id) : QObject(parent),
-    m_isInitalized(false)
+   m_entity(VfCpp::VeinModuleEntity::Ptr(new VfCpp::VeinModuleEntity(id),&QObject::deleteLater)), m_isInitalized(false)
 {
-    m_entity=new VfCpp::veinmoduleentity(id);
+    //m_entity=new VfCpp::VeinModuleEntity(id);
+    QObject::connect(m_entity.data(),&VfCpp::VeinModuleEntity::sigAttached,this,&vf_export::initOnce);
 }
 
 bool vf_export::initOnce()
 {
     if(!m_isInitalized){
         m_isInitalized=true;
-        m_entity->initModule();
-        m_entity->createComponent("EntityName","ExportModule",true);
-        m_status=m_entity->createComponent("Status",false,true);
+       // m_entity->initModule();
+        m_entity->createComponent("EntityName","ExportModule",VfCpp::cVeinModuleComponent::Direction::out);
+        m_status=m_entity->createComponent("Status",false,VfCpp::cVeinModuleComponent::Direction::out);
         m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"},{"p_parameters", "QString"}}));
         py =  new zPyInt::PythonBinding();
         if(py->init("pythonconverter_pkg.CppInterface") == true){
@@ -33,14 +34,14 @@ bool vf_export::initOnce()
     return true;
 }
 
-VfCpp::veinmoduleentity *vf_export::getVeinEntity() const
+VfCpp::VeinModuleEntity* vf_export::getVeinEntity() const
 {
-    return m_entity;
+    return m_entity.data();
 }
 
-void vf_export::setVeinEntity(VfCpp::veinmoduleentity *value)
+void vf_export::setVeinEntity(VfCpp::VeinModuleEntity* value)
 {
-    m_entity = value;
+    m_entity = VfCpp::VeinModuleEntity::Ptr(value);
 }
 
 QVariant vf_export::RPC_Convert(QVariantMap p_params)

--- a/src/vf_export.h
+++ b/src/vf_export.h
@@ -3,7 +3,7 @@
 
 #include <QObject>
 #include <veinmoduleentity.h>
-#include <veincompproxy.h>
+#include <veinsharedcomp.h>
 
 
 namespace zPyInt {
@@ -56,11 +56,11 @@ public:
      *
      * Take the return value and add it to the top EventHandler system
      */
-    VfCpp::veinmoduleentity *getVeinEntity() const;
-    void setVeinEntity(VfCpp::veinmoduleentity *value);
+    VfCpp::VeinModuleEntity* getVeinEntity() const;
+    void setVeinEntity(VfCpp::VeinModuleEntity* value);
 
 private:
-    VfCpp::veinmoduleentity *m_entity;
+    VfCpp::VeinModuleEntity::Ptr m_entity;
     bool m_isInitalized;
 
     zPyInt::PythonBinding *py;
@@ -105,7 +105,7 @@ private:
      * true: good
      * false: bad
      */
-    VfCpp::VeinCompProxy<bool> m_status;
+    VfCpp::VeinSharedComp<bool> m_status;
 
 signals:
 


### PR DESCRIPTION
-veinmoduleentity is VeinModuleEntity now.
-VeinProxyComp is VeinSharedComp now.
-cVeinModuleComponent readonly = true is Direction out now.

Signed-off-by: bhamacher <b.hamacher@zera.de>