### PR TITLE
Added filter parameter to Convert RPC.

### DIFF
--- a/src/vf_export.cpp
+++ b/src/vf_export.cpp
@@ -24,7 +24,7 @@ bool vf_export::initOnce()
         m_entity->initModule();
         m_entity->createComponent("EntityName","ExportModule",true);
         m_status=m_entity->createComponent("Status",false,true);
-        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"},{"p_parameters", "QString"}}));
+        m_entity->createRpc(this,"RPC_Convert", VfCpp::cVeinModuleRpc::Param({{"p_session", "QString"},{"p_inputPath", "QString"},{"p_outputPath", "QString"},{"p_engine", "QString"},{"p_filter" , "QString"},{"p_parameters", "QString"}}));
         py =  new zPyInt::PythonBinding();
         if(py->init("pythonconverter_pkg.CppInterface") == true){
             m_status=true;
@@ -53,6 +53,7 @@ QVariant vf_export::RPC_Convert(QVariantMap p_params)
     m_engine=p_params["p_engine"].toString();
     m_session=p_params["p_session"].toString();
     m_parameters=p_params["p_parameters"].toString();
+    m_filter=p_params["p_filter"].toString();
 
     if(m_status == false){
         retVal=false;
@@ -63,6 +64,7 @@ QVariant vf_export::RPC_Convert(QVariantMap p_params)
         py->callFunction("setEngine",{PyUnicode_FromString(m_engine.toUtf8())});
         py->callFunction("setSession",{PyUnicode_FromString(m_session.toUtf8())});
         py->callFunction("setParams",{PyUnicode_FromString(m_parameters.toUtf8())});
+        py->callFunction("setFilter",{PyUnicode_FromString(m_filter.toUtf8())});
         zPyInt::PySharedRef good =py->callFunction("checkInputFile",{});
         if(PyObject_IsTrue(good.data())){
             zPyInt::PySharedRef ret=py->callFunction("convert",{});

--- a/src/vf_export.h
+++ b/src/vf_export.h
@@ -86,6 +86,11 @@ private:
      */
     QString m_engine;
     /**
+     * @brief m_filter
+     * filter transactions by this word. Transaction must contain filter expression (no regex)
+     */
+    QString m_filter;
+    /**
      * @brief m_parameters
      * stores the engine parameters available using setParameters
      * inside the engine.


### PR DESCRIPTION
p_filtr should either be equal "". That means no filter is set.
or the filter is "<expression>". In this case only transactions with names
including the expression will be converted.

Following the Zera convem:tions using "Snapshot" as expression would end up with
only Snapshots and no records in the python conversion dict.

Signed-off-by: bhamacher <b.hamacher@zera.de>